### PR TITLE
Fix FastMCP description param

### DIFF
--- a/src/odoo_mcp/server.py
+++ b/src/odoo_mcp/server.py
@@ -8,7 +8,7 @@ import json
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Any, AsyncIterator, Dict, List, Optional, Union, cast
+from typing import Any, AsyncIterator, Dict, List, Optional, Union
 
 from mcp.server.fastmcp import Context, FastMCP
 from pydantic import BaseModel, Field
@@ -41,7 +41,7 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
 # Create MCP server
 mcp = FastMCP(
     "Odoo MCP Server",
-    description="MCP Server for interacting with Odoo ERP systems",
+    instructions="MCP Server for interacting with Odoo ERP systems",
     dependencies=["requests"],
     lifespan=app_lifespan,
 )
@@ -314,7 +314,7 @@ def execute_method(
                             parsed_domain = ast.literal_eval(domain)
                             if isinstance(parsed_domain, list):
                                 domain_list = parsed_domain
-                        except:
+                        except Exception:
                             domain_list = []
 
                 # Xác thực domain_list


### PR DESCRIPTION
## Summary
- fix FastMCP initialization to use instructions instead of deprecated description parameter
- address lint warnings by removing unused import and specifying exception type

## Testing
- `ruff check src/odoo_mcp/server.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b97bfe2ec883218d2764a4e2478bb4